### PR TITLE
0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.27.0
+
+* `Versions`:
+  * `Kotlin`: `2.3.20` -> `2.3.21`
+  * `PlaguBot`: `11.2.0` -> `12.0.0`
+  * `MicroUtils`: `0.29.2` -> `0.30.0`
+  * `TelegramBotAPILibraries`: `0.30.0` -> `0.31.0`
+  * `nmcp`: `1.4.4` -> `1.6.0`
+
 ## 0.26.0
 
 * `Versions`:

--- a/bans/src/main/kotlin/BanPlugin.kt
+++ b/bans/src/main/kotlin/BanPlugin.kt
@@ -142,7 +142,7 @@ class BanPlugin : Plugin {
         val chatsSettings = koin.get<ChatsSettingsTable>(named("chatsSettingsTable"))
         val adminsApi = koin.get<AdminsCacheAPI>()
 
-        suspend fun sayUserHisWarnings(message: AccessibleMessage, userInReply: Either<User, ChannelChat>, settings: ChatSettings, warnings: Long) {
+        suspend fun sayUserHisWarnings(message: ChatMessage, userInReply: Either<User, ChannelChat>, settings: ChatSettings, warnings: Long) {
             reply(
                 message
             ) {
@@ -157,7 +157,7 @@ class BanPlugin : Plugin {
             }
         }
         suspend fun BehaviourContext.getChatSettings(
-            fromMessage: AccessibleMessage,
+            fromMessage: ChatMessage,
             sentByAdmin: Boolean
         ): ChatSettings? {
             val chatSettings = chatsSettings.get(fromMessage.chat.id) ?: ChatSettings()

--- a/bans/src/main/kotlin/InlineButtonsDrawer.kt
+++ b/bans/src/main/kotlin/InlineButtonsDrawer.kt
@@ -21,6 +21,7 @@ import dev.inmo.tgbotapi.extensions.behaviour_builder.expectations.waitTextMessa
 import dev.inmo.tgbotapi.extensions.behaviour_builder.oneOf
 import dev.inmo.tgbotapi.extensions.behaviour_builder.parallel
 import dev.inmo.tgbotapi.extensions.behaviour_builder.triggers_handling.onMessageDataCallbackQuery
+import dev.inmo.tgbotapi.extensions.utils.chatMessageOrNull
 import dev.inmo.tgbotapi.extensions.utils.types.buttons.inlineKeyboard
 import dev.inmo.tgbotapi.libraries.cache.admins.AdminsCacheAPI
 import dev.inmo.tgbotapi.requests.send.SendTextMessage
@@ -143,7 +144,7 @@ internal class BansInlineButtonsDrawer(
         )
 
         if (needNewMessage) {
-            reply(query.message as ChatMessage, "Updated")
+            reply(query.message.chatMessageOrNull() ?: error("Message is expected to be an accessible ChatMessage"), "Updated")
         }
 
         runCatchingLogging { drawInlineButtons(chatId, query.user.id, query.message.messageId, InlineButtonsKeys.Settings) }

--- a/bans/src/main/kotlin/InlineButtonsDrawer.kt
+++ b/bans/src/main/kotlin/InlineButtonsDrawer.kt
@@ -27,6 +27,7 @@ import dev.inmo.tgbotapi.requests.send.SendTextMessage
 import dev.inmo.tgbotapi.types.IdChatIdentifier
 import dev.inmo.tgbotapi.types.MessageId
 import dev.inmo.tgbotapi.types.UserId
+import dev.inmo.tgbotapi.types.message.abstracts.ChatMessage
 import dev.inmo.tgbotapi.types.message.textsources.BotCommandTextSource
 import dev.inmo.tgbotapi.types.queries.callback.MessageDataCallbackQuery
 import dev.inmo.tgbotapi.utils.botCommand
@@ -142,7 +143,7 @@ internal class BansInlineButtonsDrawer(
         )
 
         if (needNewMessage) {
-            reply(query.message, "Updated")
+            reply(query.message as ChatMessage, "Updated")
         }
 
         runCatchingLogging { drawInlineButtons(chatId, query.user.id, query.message.messageId, InlineButtonsKeys.Settings) }

--- a/bans/src/main/kotlin/utils/CheckBanPluginEnabled.kt
+++ b/bans/src/main/kotlin/utils/CheckBanPluginEnabled.kt
@@ -5,12 +5,12 @@ import dev.inmo.plagubot.plugins.bans.models.ChatSettings
 import dev.inmo.plagubot.plugins.bans.models.WorkMode
 import dev.inmo.tgbotapi.extensions.api.send.reply
 import dev.inmo.tgbotapi.extensions.behaviour_builder.BehaviourContext
-import dev.inmo.tgbotapi.types.message.abstracts.AccessibleMessage
+import dev.inmo.tgbotapi.types.message.abstracts.ChatMessage
 import dev.inmo.tgbotapi.types.message.abstracts.Message
 import dev.inmo.tgbotapi.utils.botCommand
 
 internal suspend fun BehaviourContext.checkBanPluginEnabled(
-    sourceMessage: AccessibleMessage,
+    sourceMessage: ChatMessage,
     chatSettings: ChatSettings,
     fromAdmin: Boolean
 ): Boolean {

--- a/captcha/src/main/kotlin/Plugin.kt
+++ b/captcha/src/main/kotlin/Plugin.kt
@@ -44,6 +44,7 @@ import dev.inmo.tgbotapi.types.chat.RestrictionsChatPermissions
 import dev.inmo.tgbotapi.types.chat.User
 import dev.inmo.tgbotapi.types.commands.BotCommandScope
 import dev.inmo.tgbotapi.types.message.abstracts.AccessibleMessage
+import dev.inmo.tgbotapi.types.message.abstracts.ChatMessage
 import dev.inmo.tgbotapi.utils.buildEntities
 import dev.inmo.tgbotapi.utils.link
 import dev.inmo.tgbotapi.utils.mention
@@ -188,7 +189,7 @@ class CaptchaBotPlugin : Plugin {
         suspend fun Chat.settings() = repo.getById(id) ?: repo.create(ChatSettings(id)).first()
 
         suspend fun doCaptcha(
-            msg: AccessibleMessage?,
+            msg: ChatMessage?,
             chat: GroupChat,
             users: List<User>,
             joinRequest: Boolean

--- a/captcha/src/main/kotlin/settings/InlineSettings.kt
+++ b/captcha/src/main/kotlin/settings/InlineSettings.kt
@@ -23,6 +23,7 @@ import dev.inmo.tgbotapi.extensions.behaviour_builder.BehaviourContext
 import dev.inmo.tgbotapi.extensions.behaviour_builder.expectations.waitTextMessage
 import dev.inmo.tgbotapi.extensions.behaviour_builder.triggers_handling.onMessageDataCallbackQuery
 import dev.inmo.tgbotapi.extensions.utils.chatIdOrNull
+import dev.inmo.tgbotapi.extensions.utils.chatMessageOrNull
 import dev.inmo.tgbotapi.extensions.utils.extensions.sameChat
 import dev.inmo.tgbotapi.extensions.utils.ifChatId
 import dev.inmo.tgbotapi.extensions.utils.types.buttons.dataButton
@@ -299,7 +300,7 @@ class InlineSettings(
                     "$title: You should type number${if (minMax == null) "" else " in range $minMax"} or use /cancel"
                 }
 
-                val sentMessage = reply(it.message as ChatMessage) {
+                val sentMessage = reply(it.message.chatMessageOrNull() ?: error("Message is expected to be an accessible ChatMessage")) {
                     +"$title: Type number${if (minMax == null) "" else " in range $minMax"} or use /cancel"
                 }
 

--- a/captcha/src/main/kotlin/settings/InlineSettings.kt
+++ b/captcha/src/main/kotlin/settings/InlineSettings.kt
@@ -30,6 +30,7 @@ import dev.inmo.tgbotapi.extensions.utils.types.buttons.inlineKeyboard
 import dev.inmo.tgbotapi.types.*
 import dev.inmo.tgbotapi.types.buttons.InlineKeyboardButtons.CallbackDataInlineKeyboardButton
 import dev.inmo.tgbotapi.types.buttons.InlineKeyboardMarkup
+import dev.inmo.tgbotapi.types.message.abstracts.ChatMessage
 import dev.inmo.tgbotapi.types.queries.callback.MessageDataCallbackQuery
 import dev.inmo.tgbotapi.utils.row
 import korlibs.time.seconds
@@ -298,7 +299,7 @@ class InlineSettings(
                     "$title: You should type number${if (minMax == null) "" else " in range $minMax"} or use /cancel"
                 }
 
-                val sentMessage = reply(it.message) {
+                val sentMessage = reply(it.message as ChatMessage) {
                     +"$title: Type number${if (minMax == null) "" else " in range $minMax"} or use /cancel"
                 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ kotlin.incremental=true
 # Project data
 
 group=dev.inmo
-version=0.26.0
+version=0.27.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,15 +1,15 @@
 [versions]
 
-kotlin = "2.3.20"
+kotlin = "2.3.21"
 kotlin-serialization = "1.11.0"
 
-plagubot = "11.2.0"
+plagubot = "12.0.0"
 kslog = "1.6.1"
-microutils = "0.29.2"
+microutils = "0.30.0"
 
-tgbotapi-libraries = "0.30.0"
+tgbotapi-libraries = "0.31.0"
 
-nmcp="1.4.4"
+nmcp="1.6.0"
 
 gh-release = "2.5.2"
 dokka = "2.2.0"

--- a/welcome/src/main/kotlin/WelcomeInlineButtons.kt
+++ b/welcome/src/main/kotlin/WelcomeInlineButtons.kt
@@ -18,6 +18,7 @@ import dev.inmo.tgbotapi.extensions.behaviour_builder.BehaviourContext
 import dev.inmo.tgbotapi.extensions.behaviour_builder.expectations.waitAnyContentMessage
 import dev.inmo.tgbotapi.extensions.behaviour_builder.expectations.waitContentMessage
 import dev.inmo.tgbotapi.extensions.behaviour_builder.triggers_handling.onMessageDataCallbackQuery
+import dev.inmo.tgbotapi.types.message.abstracts.ChatMessage
 import dev.inmo.tgbotapi.extensions.utils.extensions.sameChat
 import dev.inmo.tgbotapi.extensions.utils.types.buttons.inlineKeyboard
 import dev.inmo.tgbotapi.extensions.utils.withContentOrNull
@@ -84,12 +85,12 @@ internal class WelcomeInlineButtons(
                     getMessageData -> {
                         welcomeTable.get(chatId) ?.let { settings ->
                             reply(
-                                it.message,
+                                it.message as ChatMessage,
                                 fromChatId = settings.sourceChatId,
                                 messageId = settings.sourceMessageId
                             )
                         } ?: let { _ ->
-                            reply(it.message) {
+                            reply(it.message as ChatMessage) {
                                 +"Currently welcome message is not set"
                             }
                         }
@@ -133,7 +134,7 @@ internal class WelcomeInlineButtons(
                     unsetMessageData -> {
                         val deletedSettings = welcomeTable.unset(chatId)
 
-                        reply(it.message) {
+                        reply(it.message as ChatMessage) {
                             if (deletedSettings != null) {
                                 +"Set request has been cancelled"
                             } else {

--- a/welcome/src/main/kotlin/WelcomeInlineButtons.kt
+++ b/welcome/src/main/kotlin/WelcomeInlineButtons.kt
@@ -19,6 +19,7 @@ import dev.inmo.tgbotapi.extensions.behaviour_builder.expectations.waitAnyConten
 import dev.inmo.tgbotapi.extensions.behaviour_builder.expectations.waitContentMessage
 import dev.inmo.tgbotapi.extensions.behaviour_builder.triggers_handling.onMessageDataCallbackQuery
 import dev.inmo.tgbotapi.types.message.abstracts.ChatMessage
+import dev.inmo.tgbotapi.extensions.utils.chatMessageOrNull
 import dev.inmo.tgbotapi.extensions.utils.extensions.sameChat
 import dev.inmo.tgbotapi.extensions.utils.types.buttons.inlineKeyboard
 import dev.inmo.tgbotapi.extensions.utils.withContentOrNull
@@ -85,12 +86,12 @@ internal class WelcomeInlineButtons(
                     getMessageData -> {
                         welcomeTable.get(chatId) ?.let { settings ->
                             reply(
-                                it.message as ChatMessage,
+                                it.message.chatMessageOrNull() ?: error("Message is expected to be an accessible ChatMessage"),
                                 fromChatId = settings.sourceChatId,
                                 messageId = settings.sourceMessageId
                             )
                         } ?: let { _ ->
-                            reply(it.message as ChatMessage) {
+                            reply(it.message.chatMessageOrNull() ?: error("Message is expected to be an accessible ChatMessage")) {
                                 +"Currently welcome message is not set"
                             }
                         }
@@ -134,7 +135,7 @@ internal class WelcomeInlineButtons(
                     unsetMessageData -> {
                         val deletedSettings = welcomeTable.unset(chatId)
 
-                        reply(it.message as ChatMessage) {
+                        reply(it.message.chatMessageOrNull() ?: error("Message is expected to be an accessible ChatMessage")) {
                             if (deletedSettings != null) {
                                 +"Set request has been cancelled"
                             } else {

--- a/welcome/src/main/kotlin/model/ChatSettings.kt
+++ b/welcome/src/main/kotlin/model/ChatSettings.kt
@@ -5,6 +5,7 @@ import dev.inmo.tgbotapi.bot.TelegramBot
 import dev.inmo.tgbotapi.bot.exceptions.RequestException
 import dev.inmo.tgbotapi.extensions.api.forwardMessage
 import dev.inmo.tgbotapi.extensions.api.send.copyMessage
+import dev.inmo.tgbotapi.extensions.utils.accessibleMessageOrNull
 import dev.inmo.tgbotapi.types.IdChatIdentifier
 import dev.inmo.tgbotapi.types.MessageId
 import dev.inmo.tgbotapi.types.ReplyParameters
@@ -41,7 +42,7 @@ internal suspend fun ChatSettings.sendWelcome(
                 )
                 bot.copyMessage(
                     targetChatId,
-                    forwarded as AccessibleMessage,
+                    forwarded.accessibleMessageOrNull() ?: error("Message is expected to be accessible"),
                     replyParameters = replyTo ?.let { ReplyParameters(targetChatId, it, allowSendingWithoutReply = true) },
                 )
             }.getOrNull()

--- a/welcome/src/main/kotlin/model/ChatSettings.kt
+++ b/welcome/src/main/kotlin/model/ChatSettings.kt
@@ -8,6 +8,7 @@ import dev.inmo.tgbotapi.extensions.api.send.copyMessage
 import dev.inmo.tgbotapi.types.IdChatIdentifier
 import dev.inmo.tgbotapi.types.MessageId
 import dev.inmo.tgbotapi.types.ReplyParameters
+import dev.inmo.tgbotapi.types.message.abstracts.AccessibleMessage
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -40,7 +41,7 @@ internal suspend fun ChatSettings.sendWelcome(
                 )
                 bot.copyMessage(
                     targetChatId,
-                    forwarded,
+                    forwarded as AccessibleMessage,
                     replyParameters = replyTo ?.let { ReplyParameters(targetChatId, it, allowSendingWithoutReply = true) },
                 )
             }.getOrNull()


### PR DESCRIPTION
Update to tgbotapi 35.1.0 chain.

* Versions: Kotlin 2.3.20 -> 2.3.21, PlaguBot 11.2.0 -> 12.0.0, MicroUtils 0.29.2 -> 0.30.0, TelegramBotAPILibraries 0.30.0 -> 0.31.0, nmcp 1.4.4 -> 1.6.0
* Migrated to reworked tgbotapi message hierarchy (CommonMessage -> ChatContentMessage; reply/copyMessage now typed on ChatMessage/AccessibleMessage) across bans, welcome, captcha modules